### PR TITLE
fix: stricter requirements for cache

### DIFF
--- a/packages/edge-gateway/src/constants.js
+++ b/packages/edge-gateway/src/constants.js
@@ -1,3 +1,4 @@
+// https://developers.cloudflare.com/cache/concepts/default-cache-behavior/#cacheable-size-limits
 export const CF_CACHE_MAX_OBJECT_SIZE = 512 * Math.pow(1024, 2) // 512MB to bytes
 
 export const ACCEPTABLE_DENYLIST_STATUS_CODES = [204, 400, 404]


### PR DESCRIPTION
Makes the requirements for adding to the cache stricter and in accordance with the cloudflare docs.

We only call `waitUntil` if it is possible for the response to be added to the cache. This should reduce errors and potentially worker runtimes.