### PR TITLE
feat(edge-gateway): proxy post requests

### DIFF
--- a/packages/edge-gateway/src/bindings.d.ts
+++ b/packages/edge-gateway/src/bindings.d.ts
@@ -29,6 +29,7 @@ export interface EnvInput {
   IPFS_GATEWAYS_RACE_L1: string
   IPFS_GATEWAYS_RACE_L2: string
   GATEWAY_HOSTNAME: string
+  UCANTO_SERVER_URL: string
   EDGE_GATEWAY_API_URL: string
   REQUEST_TIMEOUT?: number
   CDN_REQUEST_TIMEOUT?: number

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -257,7 +257,7 @@ async function getFromDotstorage (request, env, cid, options = {}) {
           // Cloudflare's IdentityTransformStream provides a zero copy
           // passthrough alternative to TransformStream.
           // https://developers.cloudflare.com/workers/runtime-apis/streams/transformstream/#identitytransformstream
-          IdentityTransformStream: IdentityTransformStream
+          IdentityTransformStream
         })
 
         // @ts-ignore 'response' does not exist on type 'GatewayResponseFailure'
@@ -318,7 +318,7 @@ async function getFromGatewayRacer (cid, pathname, search, headers, env, ctx) {
       // Cloudflare's IdentityTransformStream provides a zero copy
       // passthrough alternative to TransformStream.
       // https://developers.cloudflare.com/workers/runtime-apis/streams/transformstream/#identitytransformstream
-      IdentityTransformStream: IdentityTransformStream
+      IdentityTransformStream
     })
     if (!layerOneIsWinner) {
       throw new Error('no winner in the first race')

--- a/packages/edge-gateway/src/index.js
+++ b/packages/edge-gateway/src/index.js
@@ -16,6 +16,7 @@ const router = Router()
 
 router
   .all('*', envAll)
+  .post('*', withCorsHeaders(proxyPostRequest))
   .get('/version', withCorsHeaders(versionGet))
   .get('*', withCorsHeaders(gatewayGet))
   .head('*', withCorsHeaders(gatewayGet))
@@ -27,6 +28,21 @@ router
  */
 function serverError (error, request, env) {
   return addCorsHeaders(request, errorHandler(error, env))
+}
+
+/**
+ * Proxy POST requests to the UCANTO Server defined in the environment.
+ *
+ * @param {Request} request
+ * @param {import('./env').Env} env
+ * @returns {Promise<Response>}
+ */
+async function proxyPostRequest (request, env) {
+  const originRequest = new Request(request)
+  const url = new URL(request.url)
+  const targetUrl = `${env.UCANTO_SERVER_URL}${url.pathname}`
+  const response = await fetch(targetUrl, originRequest)
+  return response
 }
 
 export default {

--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -39,6 +39,7 @@ DEBUG = "false"
 CID_VERIFIER_ENABLED = "false"
 PERMA_CACHE_ENABLED = "false"
 ENV = "production"
+UCANTO_SERVER_URL = 'https://freeway.dag.haus'
 
 # TODO: Should point to general API in the future
 [[env.production.services]]
@@ -90,6 +91,7 @@ routes = [
 GATEWAY_HOSTNAME = 'ipfs-staging.dag.haus'
 CID_VERIFIER_URL = 'https://cid-verifier-staging.dag.haus'
 DENYLIST_URL = 'https://denylist-staging.dag.haus'
+UCANTO_SERVER_URL = 'https://freeway-staging.dag.haus'
 
 # TODO: Should point to general API in the future
 EDGE_GATEWAY_API_URL = 'https://api.nftstorage.link'
@@ -145,3 +147,4 @@ DEBUG = "true"
 CID_VERIFIER_ENABLED = "true"
 PERMA_CACHE_ENABLED = "true"
 ENV = "test"
+UCANTO_SERVER_URL = 'http://localhost:8000'


### PR DESCRIPTION
### Context
The Freeway Gateway will be able to handle UCAN invocations after the PR https://github.com/storacha/freeway/pull/133 gets merged. 
So we need to proxy POST requests sent to the `reads` (edge-gateway) to the new UCANTO Server.

### Related Issue
- https://github.com/storacha/project-tracking/issues/212
- https://github.com/storacha/project-tracking/issues/160