### PR TITLE
fix: handling preflight cors requests

### DIFF
--- a/packages/edge-gateway/src/cors.js
+++ b/packages/edge-gateway/src/cors.js
@@ -32,3 +32,15 @@ export function addCorsHeaders (request, response) {
   response.headers.set('Access-Control-Expose-Headers', 'Link')
   return response
 }
+
+/**
+ * @param {Request} request
+ * @returns {Response}
+ */
+export function corsPreflightRequest (request) {
+  const headers = new Headers()
+  headers.set('Access-Control-Allow-Origin', request.headers.get('origin') || '*')
+  headers.set('Access-Control-Allow-Methods', 'GET, HEAD, POST, OPTIONS')
+  headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  return new Response(null, { headers, status: 204 })
+}

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -257,7 +257,7 @@ async function getFromDotstorage (request, env, cid, options = {}) {
           // Cloudflare's IdentityTransformStream provides a zero copy
           // passthrough alternative to TransformStream.
           // https://developers.cloudflare.com/workers/runtime-apis/streams/transformstream/#identitytransformstream
-          IdentityTransformStream: IdentityTransformStream
+          IdentityTransformStream
         })
 
         // @ts-ignore 'response' does not exist on type 'GatewayResponseFailure'
@@ -318,7 +318,7 @@ async function getFromGatewayRacer (cid, pathname, search, headers, env, ctx) {
       // Cloudflare's IdentityTransformStream provides a zero copy
       // passthrough alternative to TransformStream.
       // https://developers.cloudflare.com/workers/runtime-apis/streams/transformstream/#identitytransformstream
-      IdentityTransformStream: IdentityTransformStream
+      IdentityTransformStream
     })
     if (!layerOneIsWinner) {
       throw new Error('no winner in the first race')

--- a/packages/edge-gateway/src/index.js
+++ b/packages/edge-gateway/src/index.js
@@ -5,7 +5,7 @@ import { Router } from 'itty-router'
 import { gatewayGet } from './gateway.js'
 import { versionGet } from './version.js'
 
-import { addCorsHeaders, withCorsHeaders } from './cors.js'
+import { addCorsHeaders, withCorsHeaders, corsPreflightRequest } from './cors.js'
 import { errorHandler } from './error-handler.js'
 import { envAll } from './env.js'
 
@@ -16,6 +16,7 @@ const router = Router()
 
 router
   .all('*', envAll)
+  .options('*', corsPreflightRequest)
   .get('/version', withCorsHeaders(versionGet))
   .get('*', withCorsHeaders(gatewayGet))
   .head('*', withCorsHeaders(gatewayGet))


### PR DESCRIPTION
### Changes
- I noticed that the preflights sent to `https://w3s.link` are still redirected, and I saw this is the worker bound to receive the request. It doesn't support preflight requests, so I added the config.